### PR TITLE
Support monad-logger

### DIFF
--- a/canteven-log.cabal
+++ b/canteven-log.cabal
@@ -20,6 +20,8 @@ library
   exposed-modules:     
     Canteven.Log
   -- other-modules:       
+  other-modules:
+    Canteven.Log.Types
   -- other-extensions:    
   build-depends:
     aeson,

--- a/canteven-log.cabal
+++ b/canteven-log.cabal
@@ -35,7 +35,7 @@ library
     monad-logger,
     template-haskell,
     text,
-    time,
+    time >= 1.5 && <1.6,
     transformers,
     yaml
   hs-source-dirs:      src

--- a/canteven-log.cabal
+++ b/canteven-log.cabal
@@ -18,19 +18,25 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     
-    Canteven.Log
-  -- other-modules:       
+    Canteven.Log,
+    Canteven.Log.MonadLog
   other-modules:
     Canteven.Log.Types
   -- other-extensions:    
   build-depends:
     aeson,
     base >= 4 && < 5,
+    bytestring,
     canteven-config >= 1.0 && < 1.1,
     directory,
+    fast-logger,
     filepath,
     hslogger,
+    monad-logger,
+    template-haskell,
     text,
+    time,
+    transformers,
     yaml
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/canteven-log.cabal
+++ b/canteven-log.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                canteven-log
-version:             0.2.0.0
+version:             0.2.1.0
 synopsis:            A canteven way of setting up logging for your program.
 -- description:         
 homepage:            https://github.com/SumAll/haskell-canteven-log

--- a/src/Canteven/Log.hs
+++ b/src/Canteven/Log.hs
@@ -53,7 +53,7 @@ installConfig LoggingConfig {logfile, level = LP level, loggers} = do
   updateGlobalLogger "" (setLevel level . setHandlers handlers)
   sequence_ [
       updateGlobalLogger loggerName (setLevel loggerLevel) |
-      LoggerDetails {loggerName, loggerLevel = LP loggerLevel} <- loggers
+      LoggerDetails {loggerName=Just loggerName, loggerLevel = LP loggerLevel} <- loggers
     ]
   where
     tweak h = setFormatter h (simpleLogFormatter logFormat)

--- a/src/Canteven/Log.hs
+++ b/src/Canteven/Log.hs
@@ -10,19 +10,19 @@ module Canteven.Log (
   setupLogging
 ) where
 
-import Control.Applicative ((<$>), (<*>))
-import Data.Aeson (Value(String, Object), (.:?), (.!=), (.:))
-import Data.Yaml (FromJSON(parseJSON))
+import Canteven.Log.Types (LogPriority(LP),
+    LoggingConfig(LoggingConfig, logfile, level, loggers),
+    LoggerDetails(LoggerDetails, loggerName, loggerLevel))
+import Control.Applicative ((<$>))
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (dropFileName)
 import System.IO (stdout)
-import System.Log (Priority(INFO, DEBUG))
+import System.Log (Priority(DEBUG))
 import System.Log.Formatter (simpleLogFormatter)
 import System.Log.Handler (setFormatter)
 import System.Log.Handler.Simple (fileHandler, streamHandler)
 import System.Log.Logger (updateGlobalLogger, setHandlers, setLevel)
 import qualified Canteven.Config as Config (canteven)
-import qualified Data.Text as T
 
 
 {- |
@@ -58,68 +58,3 @@ installConfig LoggingConfig {logfile, level = LP level, loggers} = do
   where
     tweak h = setFormatter h (simpleLogFormatter logFormat)
     logFormat = "$prio [$tid] [$time] $loggername - $msg"
-
-
-data LoggingConfig =
-  LoggingConfig {
-    level :: LogPriority,
-    logfile :: Maybe FilePath,
-    loggers :: [LoggerDetails]
-  }
-
-instance FromJSON LoggingConfig where
-  parseJSON (Object topLevel) = do
-    mLogging <- topLevel .:? "logging"
-    case mLogging of
-      Nothing -> return defaultLogging
-      Just logging -> LoggingConfig
-        <$> logging .:? "level" .!= LP INFO
-        <*> logging .:? "logfile"
-        <*> logging .:? "loggers" .!= []
-
-  parseJSON value =
-    fail $ "Couldn't parse logging config from value " ++ show value
-
-
-{- |
-  Don't bother with @data-default@. `LoggingConfig` is not exposed and
-  the fewer dependencies the better.
--}
-defaultLogging :: LoggingConfig
-defaultLogging = LoggingConfig {
-    level = LP INFO,
-    logfile = Nothing,
-    loggers = []
-  }
-
-
-{- |
-  A wrapper for Priority, so we can avoid orphan instances
--}
-newtype LogPriority = LP Priority
-
-instance FromJSON LogPriority where
-  parseJSON (String s) = case reads (T.unpack s) of
-    [(priority, "")] -> return (LP priority)
-    _ -> fail $ "couldn't parse Priority from string " ++ show s
-  parseJSON value = fail $ "Couldn't parse Priority from value " ++ show value
-
-
-{- |
-  A way to set more fined-grained configuration for specific loggers.
--}
-data LoggerDetails =
-  LoggerDetails {
-    loggerName :: String,
-    loggerLevel :: LogPriority
-  }
-
-instance FromJSON LoggerDetails where
-  parseJSON (Object details) = do
-    loggerName <- details .: "logger"
-    loggerLevel <- details .: "level"
-    return LoggerDetails {loggerName, loggerLevel}
-  parseJSON value =
-    fail $ "Couldn't parse logger details from value " ++ show value
-
-

--- a/src/Canteven/Log.hs
+++ b/src/Canteven/Log.hs
@@ -57,4 +57,4 @@ installConfig LoggingConfig {logfile, level = LP level, loggers} = do
     ]
   where
     tweak h = setFormatter h (simpleLogFormatter logFormat)
-    logFormat = "$prio [$tid] [$time] $loggername - $msg"
+    logFormat = "[$time] $prio $loggername[$tid]: $msg"

--- a/src/Canteven/Log.hs
+++ b/src/Canteven/Log.hs
@@ -53,7 +53,7 @@ installConfig LoggingConfig {logfile, level = LP level, loggers} = do
   updateGlobalLogger "" (setLevel level . setHandlers handlers)
   sequence_ [
       updateGlobalLogger loggerName (setLevel loggerLevel) |
-      LoggerDetails {loggerName=Just loggerName, loggerLevel = LP loggerLevel} <- loggers
+      LoggerDetails {loggerName = Just loggerName, loggerLevel = LP loggerLevel} <- loggers
     ]
   where
     tweak h = setFormatter h (simpleLogFormatter logFormat)

--- a/src/Canteven/Log/MonadLog.hs
+++ b/src/Canteven/Log/MonadLog.hs
@@ -164,13 +164,14 @@ cantevenLogFormat loc src level msg t tid =
     (if T.null src
         then mempty
         else toLogStr src) <>
-    "@" <> toLogStr (loc_module loc) <> "[" <>
+    "@" <> toLogStr (loc_package loc ++ ":" ++ loc_module loc) <>
+    "[" <>
     toLogStr (show tid) <> "]: " <>
     msg <> " (" <> toLogStr (S8.pack fileLocStr) <> ")\n"
   where
     fmtTime = formatTime defaultTimeLocale "%F %X %Z"
-    fileLocStr = loc_package loc ++
-      ' ' : loc_filename loc ++ ':' : line loc ++ ':' : char loc
+    fileLocStr =
+        loc_filename loc ++ ':' : line loc ++ ':' : char loc
       where
         line = show . fst . loc_start
         char = show . snd . loc_start

--- a/src/Canteven/Log/MonadLog.hs
+++ b/src/Canteven/Log/MonadLog.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Canteven.Log.MonadLog (
+    cantevenOutput,
+    getRunCantevenLoggingT,
+    runCantevenLoggingDefaultT,
+    ) where
+
+import Canteven.Config (canteven)
+import Canteven.Log.Types (LoggingConfig(LoggingConfig, logfile),
+    defaultLogging)
+import Control.Applicative ((<$>))
+import Control.Concurrent (ThreadId, myThreadId)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Logger (LogSource, LogLevel(LevelOther),
+    LoggingT(runLoggingT))
+import Data.Char (toUpper)
+import Data.Monoid ((<>), mempty)
+import Data.Time.Clock (UTCTime, getCurrentTime)
+import Language.Haskell.TH (Loc(loc_filename, loc_package, loc_module,
+    loc_start))
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath (dropFileName)
+import System.IO (Handle, IOMode(AppendMode), openFile, stdout)
+import System.Log.FastLogger (LogStr, fromLogStr, toLogStr)
+import qualified Data.ByteString.Char8 as S8
+import qualified Data.Text as T
+
+runCantevenLoggingT
+    :: (MonadIO io)
+    => LoggingConfig
+    -> LoggingT io a
+    -> io a
+runCantevenLoggingT config = (`runLoggingT` cantevenOutput config)
+
+-- | Get the logging config using canteven, and produce a way to use that
+-- logging config to run a LoggingT.
+getRunCantevenLoggingT
+    :: (Functor io1, MonadIO io1, MonadIO io2)
+    => io1 (LoggingT io2 a -> io2 a)
+getRunCantevenLoggingT =
+    runCantevenLoggingT <$> liftIO canteven
+
+-- | Run a LoggingT, using the canteven logging format, with the default logging
+-- configuration.
+runCantevenLoggingDefaultT
+    :: (MonadIO io)
+    => LoggingT io a
+    -> io a
+runCantevenLoggingDefaultT = runCantevenLoggingT defaultLogging
+
+cantevenOutput
+    :: LoggingConfig
+    -> Loc
+    -> LogSource
+    -> LogLevel
+    -> LogStr
+    -> IO ()
+cantevenOutput LoggingConfig {logfile} loc src level msg = do
+    time <- getCurrentTime
+    threadId <- myThreadId
+    handle <- maybe (return stdout) openFileForLogging logfile
+    S8.hPutStr handle . fromLogStr $ cantevenLogFormat loc src level msg time threadId
+
+-- | This is similar to the version defined in monad-logger (which we can't
+-- share because of privacy restrictions), but with the added nuance of
+-- uppercasing.
+cantevenLogLevelStr :: LogLevel -> LogStr
+cantevenLogLevelStr level = case level of
+    LevelOther t -> toLogStr $ T.toUpper t
+    _            -> toLogStr $ S8.pack $ map toUpper $ drop 5 $ show level
+
+-- | This log format is inspired by syslog and the X.org log
+-- formats. Rationales are:
+--
+-- * Put the date first, because the date string tends to be a fixed number
+--   of characters (or +/- 1 around changes to DST), so the eye can easily
+--   skim over them.
+--
+-- * The "source" of a message comes before the message itself. "Source" is
+--   composed of not just the "logger name" (called a source in
+--   monad-logger), but also the package/module name and the thread
+--   ID. Package and module name might seem controversial, but they
+--   correspond to e.g. Log4J logger names based on classes.
+--
+-- * Filename/position of the message is perhaps the least important, but
+--   can still be helpful. Put it at the end.
+cantevenLogFormat
+    :: Loc
+    -> LogSource
+    -> LogLevel
+    -> LogStr
+    -> UTCTime
+    -> ThreadId
+    -> LogStr
+cantevenLogFormat loc src level msg t tid =
+    "[" <> toLogStr (show t) <> "] " <>
+    cantevenLogLevelStr level <>
+    " " <>
+    (if T.null src
+        then mempty
+        else toLogStr src) <>
+    "@" <> toLogStr (loc_module loc) <> "[" <>
+    toLogStr (show tid) <> "]: " <>
+    msg <> " (" <> toLogStr (S8.pack fileLocStr) <> ")\n"
+  where
+    fileLocStr = loc_package loc ++
+      ' ' : loc_filename loc ++ ':' : line loc ++ ':' : char loc
+      where
+        line = show . fst . loc_start
+        char = show . snd . loc_start
+
+openFileForLogging :: FilePath -> IO Handle
+openFileForLogging filename = do
+    createDirectoryIfMissing True (dropFileName filename)
+    openFile filename AppendMode

--- a/src/Canteven/Log/Types.hs
+++ b/src/Canteven/Log/Types.hs
@@ -59,18 +59,30 @@ instance FromJSON LogPriority where
 
 
 {- |
-  A way to set more fined-grained configuration for specific loggers.
+  A way to set more fined-grained configuration for specific log messages.
+
+  Name, package, and module are "selectors" that identify which messages should
+  be configured.
+
+  'loggerLevel' is a "minimum priority". Messages that aren't at least as severe
+  as this will not be logged.
+
+  hslogger only supports "name". monad-logger supports all three.
 -}
 data LoggerDetails =
   LoggerDetails {
-    loggerName :: String,
+    loggerName :: Maybe String,
+    loggerPackage :: Maybe String,
+    loggerModule :: Maybe String,
     loggerLevel :: LogPriority
   }
 
 instance FromJSON LoggerDetails where
   parseJSON (Object details) = do
-    loggerName <- details .: "logger"
+    loggerName <- details .:? "logger"
     loggerLevel <- details .: "level"
-    return LoggerDetails {loggerName, loggerLevel}
+    loggerModule <- details .:? "module"
+    loggerPackage <- details .:? "package"
+    return LoggerDetails {loggerName, loggerPackage, loggerModule, loggerLevel}
   parseJSON value =
     fail $ "Couldn't parse logger details from value " ++ show value

--- a/src/Canteven/Log/Types.hs
+++ b/src/Canteven/Log/Types.hs
@@ -8,6 +8,7 @@ module Canteven.Log.Types (
     ) where
 
 import Data.Aeson (Value(String, Object), (.:?), (.!=), (.:))
+import Data.Maybe (catMaybes, listToMaybe)
 import Data.Yaml (FromJSON(parseJSON))
 import Control.Applicative ((<$>), (<*>))
 import System.Log (Priority(INFO))
@@ -81,7 +82,12 @@ data LoggerDetails =
 
 instance FromJSON LoggerDetails where
   parseJSON (Object details) = do
-    loggerName <- details .:? "logger"
+    loggerName <- do
+        names <- catMaybes <$> sequence [
+            details .:? "logger",
+            details .:? "source",
+            details .:? "name"]
+        return $ listToMaybe names
     loggerLevel <- details .: "level"
     loggerModule <- details .:? "module"
     loggerPackage <- details .:? "package"

--- a/src/Canteven/Log/Types.hs
+++ b/src/Canteven/Log/Types.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Canteven.Log.Types (
+    LogPriority(..),
+    LoggerDetails(..),
+    LoggingConfig(..),
+    defaultLogging,
+    ) where
+
+import Data.Aeson (Value(String, Object), (.:?), (.!=), (.:))
+import Data.Yaml (FromJSON(parseJSON))
+import Control.Applicative ((<$>), (<*>))
+import System.Log (Priority(INFO))
+import qualified Data.Text as T
+
+data LoggingConfig =
+  LoggingConfig {
+    level :: LogPriority,
+    logfile :: Maybe FilePath,
+    loggers :: [LoggerDetails]
+  }
+
+instance FromJSON LoggingConfig where
+  parseJSON (Object topLevel) = do
+    mLogging <- topLevel .:? "logging"
+    case mLogging of
+      Nothing -> return defaultLogging
+      Just logging -> LoggingConfig
+        <$> logging .:? "level" .!= LP INFO
+        <*> logging .:? "logfile"
+        <*> logging .:? "loggers" .!= []
+
+  parseJSON value =
+    fail $ "Couldn't parse logging config from value " ++ show value
+
+
+{- |
+  Don't bother with @data-default@. `LoggingConfig` is not exposed and
+  the fewer dependencies the better.
+-}
+defaultLogging :: LoggingConfig
+defaultLogging = LoggingConfig {
+    level = LP INFO,
+    logfile = Nothing,
+    loggers = []
+  }
+
+
+{- |
+  A wrapper for Priority, so we can avoid orphan instances
+-}
+newtype LogPriority = LP Priority
+
+instance FromJSON LogPriority where
+  parseJSON (String s) = case reads (T.unpack s) of
+    [(priority, "")] -> return (LP priority)
+    _ -> fail $ "couldn't parse Priority from string " ++ show s
+  parseJSON value = fail $ "Couldn't parse Priority from value " ++ show value
+
+
+{- |
+  A way to set more fined-grained configuration for specific loggers.
+-}
+data LoggerDetails =
+  LoggerDetails {
+    loggerName :: String,
+    loggerLevel :: LogPriority
+  }
+
+instance FromJSON LoggerDetails where
+  parseJSON (Object details) = do
+    loggerName <- details .: "logger"
+    loggerLevel <- details .: "level"
+    return LoggerDetails {loggerName, loggerLevel}
+  parseJSON value =
+    fail $ "Couldn't parse logger details from value " ++ show value

--- a/src/Canteven/Log/Types.hs
+++ b/src/Canteven/Log/Types.hs
@@ -62,7 +62,9 @@ instance FromJSON LogPriority where
   A way to set more fined-grained configuration for specific log messages.
 
   Name, package, and module are "selectors" that identify which messages should
-  be configured.
+  be configured. Any absent "selectors" match everything. Name and package have to
+  match exactly. Module can either match exactly, or -- if the config specifies a
+  module ending in an asterisk -- match a prefix.
 
   'loggerLevel' is a "minimum priority". Messages that aren't at least as severe
   as this will not be logged.


### PR DESCRIPTION
canteven-log already supports hslogger. Add some functions for running monad-logger monads in a compatible way.

monad-logger actions provide a little more information than hslogger actions do. In particular, monad-logger offers Template Haskell functions that automatically record module and filename where they are used. Offer mechanisms to filter on any of those, or multiple at the same time. We match exactly on logger name (known by the names "logger", "name", and "source") and package, but offer prefix matching for "module" (if it ends with a "*").

I wasn't sure whether this belongs in canteven-log. In particular, this means that anyone using canteven-log pulls in all the dependencies for *both* logging systems. On the other hand, it seemed like we would want a single library that manages whatever logging library we use in a given place.