### PR TITLE
Expose canteven log runner and log format

### DIFF
--- a/canteven-log.cabal
+++ b/canteven-log.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                canteven-log
-version:             0.2.2.0
+version:             0.3.0.0
 synopsis:            A canteven way of setting up logging for your program.
 -- description:         
 homepage:            https://github.com/SumAll/haskell-canteven-log

--- a/canteven-log.cabal
+++ b/canteven-log.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                canteven-log
-version:             0.2.1.0
+version:             0.2.2.0
 synopsis:            A canteven way of setting up logging for your program.
 -- description:         
 homepage:            https://github.com/SumAll/haskell-canteven-log

--- a/src/Canteven/Log/MonadLog.hs
+++ b/src/Canteven/Log/MonadLog.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Canteven.Log.MonadLog (
+    LoggerTImpl,
     cantevenLogFormat,
     getRunCantevenLoggingT,
     getCantevenOutput,
@@ -38,6 +39,8 @@ import System.Log.Logger (Priority(DEBUG, INFO, NOTICE, WARNING, ERROR,
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.Text as T
 
+type LoggerTImpl = Loc -> LogSource -> LogLevel -> LogStr -> IO ()
+
 runCantevenLoggingT
     :: (MonadIO io)
     => LoggingConfig
@@ -55,7 +58,7 @@ getRunCantevenLoggingT =
 
 getCantevenOutput
     :: (Functor io, MonadIO io)
-    => io (Loc -> LogSource -> LogLevel -> LogStr -> IO ())
+    => io LoggerTImpl
 getCantevenOutput =
     cantevenOutput <$> liftIO canteven
 

--- a/src/Canteven/Log/MonadLog.hs
+++ b/src/Canteven/Log/MonadLog.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Canteven.Log.MonadLog (
+    cantevenLogFormat,
     getRunCantevenLoggingT,
     getCantevenOutput,
     runCantevenLoggingDefaultT,

--- a/src/Canteven/Log/MonadLog.hs
+++ b/src/Canteven/Log/MonadLog.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Canteven.Log.MonadLog (
-    cantevenOutput,
     getRunCantevenLoggingT,
+    getCantevenOutput,
     runCantevenLoggingDefaultT,
     ) where
 
@@ -51,6 +51,12 @@ getRunCantevenLoggingT
     => io1 (LoggingT io2 a -> io2 a)
 getRunCantevenLoggingT =
     runCantevenLoggingT <$> liftIO canteven
+
+getCantevenOutput
+    :: (Functor io, MonadIO io)
+    => io (Loc -> LogSource -> LogLevel -> LogStr -> IO ())
+getCantevenOutput =
+    cantevenOutput <$> liftIO canteven
 
 -- | Run a LoggingT, using the canteven logging format, with the default logging
 -- configuration.


### PR DESCRIPTION
I am building a service where I want to do clever things with log messages. Specifically:

- I want to modify log messages with additional information
- I want to capture log messages as they go by so that I can display them interactively

For this reason, it's helpful to have more access to the canteven-log LoggingT function as well as the log formatter.