### PR TITLE
Changed time format ...

### DIFF
--- a/canteven-log.cabal
+++ b/canteven-log.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                canteven-log
-version:             0.3.0.2
+version:             0.3.0.3
 synopsis:            A canteven way of setting up logging for your program.
 description:
     A library that uses <https://hackage.haskell.org/package/canteven-config canteven-config>

--- a/src/Canteven/Log/MonadLog.hs
+++ b/src/Canteven/Log/MonadLog.hs
@@ -187,7 +187,7 @@ cantevenLogFormat loc src level msg t tid =
     toLogStr (show tid) <> "]: " <>
     msg <> " (" <> toLogStr (S8.pack fileLocStr) <> ")\n"
   where
-    fmtTime = formatTime defaultTimeLocale "%F %X %Z"
+    fmtTime = formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S.%q %Z"
     fileLocStr =
         loc_filename loc ++ ':' : line loc ++ ':' : char loc
       where


### PR DESCRIPTION
... to ISO-8601, which 1) can be lexicographically sorted, for the
case where you might be merging log files, and 2) has higher precision
than seconds, because a lot can happen in one second on today's modern
computers, which are so advanced they can fit into a single room.

Really, the whole log message format should be configurable, but I
don't feel like tackling that right now.